### PR TITLE
perf: #5 refactor config props

### DIFF
--- a/lib/config_props.dart
+++ b/lib/config_props.dart
@@ -3,60 +3,50 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:raygun_cli/environment.dart';
 
-/// Configuration properties for the Raygun CLI
-class ConfigProps {
-  /// Raygun's application ID
-  final String appId;
+/// A Config property is a value
+/// that can be set via argument
+/// or environment variable.
+class ConfigProp {
+  static const appIdProp = ConfigProp(
+    name: 'app-id',
+    envKey: Environment.raygunAppIdKey,
+  );
 
-  /// Raygun's access token
-  final String token;
+  static const tokenProp = ConfigProp(
+    name: 'token',
+    envKey: Environment.raygunTokenKey,
+  );
 
-  ConfigProps._({
-    required this.appId,
-    required this.token,
+  static const apiKeyProp = ConfigProp(
+    name: 'api-key',
+    envKey: Environment.raygunApiKeyKey,
+  );
+
+  /// The name of the property
+  final String name;
+
+  /// The environment variable key
+  final String envKey;
+
+  const ConfigProp({
+    required this.name,
+    required this.envKey,
   });
 
-  /// Load configuration properties from arguments or environment variables
-  /// and return a new instance of [ConfigProps] or exit with code 2.
-  factory ConfigProps.load(ArgResults arguments, {bool verbose = false}) {
-    String? appId;
-    String? token;
-
-    // Providing app-id and token via argument takes priority
-    if (arguments.wasParsed('app-id')) {
-      appId = arguments['app-id'];
+  /// Load the value of the property from arguments or environment variables
+  String loadFrom(ArgResults arguments) {
+    String? value;
+    if (arguments.wasParsed(name)) {
+      value = arguments[name];
     } else {
-      appId = Environment.instance.raygunAppId;
+      value = Environment.instance[envKey];
     }
-
-    if (appId == null) {
-      print('Error: Missing "app-id"');
+    if (value == null) {
+      print('Error: Missing "$name"');
       print(
-          '  Please provide "app-id" via argument or environment variable "RAYGUN_APP_ID"');
+          '  Please provide "$name" via argument or environment variable "$envKey"');
       exit(2);
     }
-
-    if (arguments.wasParsed('token')) {
-      token = arguments['token'];
-    } else {
-      token = Environment.instance.raygunToken;
-    }
-
-    if (token == null) {
-      print('Error: Missing "token"');
-      print(
-          '  Please provide "token" via argument or environment variable "RAYGUN_TOKEN"');
-      exit(2);
-    }
-
-    if (verbose) {
-      print('App ID: $appId');
-      print('Token: $token');
-    }
-
-    return ConfigProps._(
-      appId: appId,
-      token: token,
-    );
+    return value;
   }
 }

--- a/lib/deployments/deployments.dart
+++ b/lib/deployments/deployments.dart
@@ -7,40 +7,31 @@ import '../config_props.dart';
 class Deployments {
   final ArgResults command;
   final bool verbose;
-  late final String appId;
   late final String token;
+  late final String apiKey;
 
   Deployments({
     required this.command,
     required this.verbose,
-    required ConfigProps config,
-  }) {
-    appId = config.appId;
-    token = config.token;
-  }
+  });
 
   Future<void> notify() async {
-    if (!command.wasParsed('api-key')) {
-      print('Error: Missing "--api-key"');
-      print('  Please provide "--api-key" via argument');
-      exit(2);
-    }
     if (!command.wasParsed('version')) {
       print('Error: Missing "--version"');
       print('  Please provide "--version" via argument');
       exit(2);
     }
 
-    final apiKey = command.option('api-key') as String;
     final version = command.option('version') as String;
     final ownerName = command.option('owner-name');
     final emailAddress = command.option('email-address');
     final comment = command.option('comment');
     final scmIdentifier = command.option('scm-identifier');
     final scmType = command.option('scm-type');
+    final apiKey = ConfigProp.apiKeyProp.loadFrom(command);
+    final token = ConfigProp.tokenProp.loadFrom(command);
 
     if (verbose) {
-      print('app-id: $appId');
       print('token: $token');
       print('api-key: $apiKey');
       print('version: $version');

--- a/lib/deployments/deployments_command.dart
+++ b/lib/deployments/deployments_command.dart
@@ -3,8 +3,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:raygun_cli/deployments/deployments.dart';
 
-import '../config_props.dart';
-
 const kDeploymentsCommand = 'deployments';
 
 ArgParser buildParserDeployments() {
@@ -14,10 +12,6 @@ ArgParser buildParserDeployments() {
       abbr: 'h',
       negatable: false,
       help: 'Print deployments usage information',
-    )
-    ..addOption(
-      'app-id',
-      help: 'Raygun application ID',
     )
     ..addOption(
       'token',
@@ -70,11 +64,8 @@ void parseDeploymentsCommand(ArgResults command, bool verbose) {
     exit(0);
   }
 
-  final configProps = ConfigProps.load(command, verbose: verbose);
-
   Deployments(
     command: command,
     verbose: verbose,
-    config: configProps,
   ).notify();
 }

--- a/lib/environment.dart
+++ b/lib/environment.dart
@@ -3,11 +3,13 @@ import 'dart:io';
 /// Wraps access to Environment variables
 /// Allows faking for testing
 class Environment {
-  static String raygunAppIdKey = 'RAYGUN_APP_ID';
-  static String raygunTokenKey = 'RAYGUN_TOKEN';
+  static const String raygunAppIdKey = 'RAYGUN_APP_ID';
+  static const String raygunTokenKey = 'RAYGUN_TOKEN';
+  static const String raygunApiKeyKey = 'RAYGUN_API_KEY';
 
   final String? raygunAppId;
   final String? raygunToken;
+  final String? raygunApiKey;
 
   static Environment? _instance;
 
@@ -27,14 +29,30 @@ class Environment {
   Environment({
     required this.raygunAppId,
     required this.raygunToken,
+    required this.raygunApiKey,
   });
+
+  String? operator [](String key) {
+    switch (key) {
+      case raygunAppIdKey:
+        return raygunAppId;
+      case raygunTokenKey:
+        return raygunToken;
+      case raygunApiKeyKey:
+        return raygunApiKey;
+      default:
+        return null;
+    }
+  }
 
   factory Environment._init() {
     final raygunAppId = Platform.environment[raygunAppIdKey];
     final raygunToken = Platform.environment[raygunTokenKey];
+    final raygunApiKey = Platform.environment[raygunApiKeyKey];
     return Environment(
       raygunAppId: raygunAppId,
       raygunToken: raygunToken,
+      raygunApiKey: raygunApiKey
     );
   }
 }

--- a/lib/sourcemap/flutter/sourcemap_flutter.dart
+++ b/lib/sourcemap/flutter/sourcemap_flutter.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:raygun_cli/config_props.dart';
 import 'package:raygun_cli/sourcemap/sourcemap_api.dart';
 import 'package:raygun_cli/sourcemap/sourcemap_base.dart';
 
@@ -7,7 +8,6 @@ class SourcemapFlutter extends SourcemapBase {
   SourcemapFlutter({
     required super.command,
     required super.verbose,
-    required super.config,
   });
 
   @override
@@ -19,6 +19,8 @@ class SourcemapFlutter extends SourcemapBase {
     final uri =
         command.option('uri') ?? '${command.option('base-uri')}main.dart.js';
     final path = command.option('input-map') ?? 'build/web/main.dart.js.map';
+    final appId = ConfigProp.appIdProp.loadFrom(command);
+    final token = ConfigProp.tokenProp.loadFrom(command);
     if (verbose) {
       print('app-id: $appId');
       print('token: $token');

--- a/lib/sourcemap/node/sourcemap_node.dart
+++ b/lib/sourcemap/node/sourcemap_node.dart
@@ -6,7 +6,6 @@ class SourcemapNode extends SourcemapBase {
   SourcemapNode({
     required super.command,
     required super.verbose,
-    required super.config,
   });
 
   @override

--- a/lib/sourcemap/sourcemap_base.dart
+++ b/lib/sourcemap/sourcemap_base.dart
@@ -1,21 +1,13 @@
 import 'package:args/args.dart';
 
-import '../config_props.dart';
-
 abstract class SourcemapBase {
   SourcemapBase({
     required this.command,
     required this.verbose,
-    required ConfigProps config,
-  }) {
-    appId = config.appId;
-    token = config.token;
-  }
+  });
 
   final ArgResults command;
   final bool verbose;
-  late final String appId;
-  late final String token;
 
   Future<void> upload();
 }

--- a/lib/sourcemap/sourcemap_command.dart
+++ b/lib/sourcemap/sourcemap_command.dart
@@ -5,8 +5,6 @@ import 'package:raygun_cli/sourcemap/flutter/sourcemap_flutter.dart';
 import 'package:raygun_cli/sourcemap/node/sourcemap_node.dart';
 import 'package:raygun_cli/sourcemap/sourcemap_single_file.dart';
 
-import '../config_props.dart';
-
 const kSourcemapCommand = 'sourcemap';
 
 ArgParser buildParserSourcemap() {

--- a/lib/sourcemap/sourcemap_command.dart
+++ b/lib/sourcemap/sourcemap_command.dart
@@ -56,26 +56,22 @@ void parseSourcemapCommand(ArgResults command, bool verbose) {
     print(buildParserSourcemap().usage);
     exit(0);
   }
-  final configProps = ConfigProps.load(command, verbose: verbose);
 
   switch (command.option('platform')) {
     case null:
       SourcemapSingleFile(
         command: command,
         verbose: verbose,
-        config: configProps,
       ).upload();
     case 'flutter':
       SourcemapFlutter(
         command: command,
         verbose: verbose,
-        config: configProps,
       ).upload();
     case 'node':
       SourcemapNode(
         command: command,
         verbose: verbose,
-        config: configProps,
       ).upload();
     default:
       print('Unsupported platform');

--- a/lib/sourcemap/sourcemap_single_file.dart
+++ b/lib/sourcemap/sourcemap_single_file.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:raygun_cli/config_props.dart';
 import 'package:raygun_cli/sourcemap/sourcemap_api.dart';
 import 'package:raygun_cli/sourcemap/sourcemap_base.dart';
 
@@ -7,7 +8,6 @@ class SourcemapSingleFile extends SourcemapBase {
   SourcemapSingleFile({
     required super.command,
     required super.verbose,
-    required super.config,
   });
 
   @override
@@ -23,6 +23,9 @@ class SourcemapSingleFile extends SourcemapBase {
       exit(2);
     }
     final path = command.option('input-map')!;
+
+    final appId = ConfigProp.appIdProp.loadFrom(command);
+    final token = ConfigProp.tokenProp.loadFrom(command);
 
     if (verbose) {
       print('app-id: $appId');

--- a/lib/symbols/flutter_symbols.dart
+++ b/lib/symbols/flutter_symbols.dart
@@ -13,11 +13,10 @@ void parseSymbolsCommand(ArgResults command, bool verbose) {
     print(buildParserSymbols().usage);
     exit(0);
   }
-  final configProps = ConfigProps.load(command, verbose: verbose);
   _run(
     command: command,
-    appId: configProps.appId,
-    token: configProps.token,
+    appId: ConfigProp.appIdProp.loadFrom(command),
+    token: ConfigProp.tokenProp.loadFrom(command),
   ).then((result) {
     if (result) {
       exit(0);

--- a/test/config_props_test.dart
+++ b/test/config_props_test.dart
@@ -12,9 +12,10 @@ void main() {
         ..addOption('token');
       final results =
           parser.parse(['--app-id=app-id-parsed', '--token=token-parsed']);
-      final props = ConfigProps.load(results);
-      expect(props.appId, 'app-id-parsed');
-      expect(props.token, 'token-parsed');
+      final token = ConfigProp.tokenProp.loadFrom(results);
+      final appId = ConfigProp.appIdProp.loadFrom(results);
+      expect(appId, 'app-id-parsed');
+      expect(token, 'token-parsed');
     });
 
     test('should parse from env vars', () {
@@ -23,6 +24,7 @@ void main() {
         Environment(
           raygunAppId: 'app-id-env',
           raygunToken: 'token-env',
+          raygunApiKey: 'api-key-env',
         ),
       );
 
@@ -30,15 +32,19 @@ void main() {
       ArgParser parser = ArgParser()
         ..addFlag('verbose')
         ..addOption('app-id')
+        ..addOption('api-key')
         ..addOption('token');
 
       // parse nothing
       final results = parser.parse([]);
 
       // load from env vars
-      final props = ConfigProps.load(results);
-      expect(props.appId, 'app-id-env');
-      expect(props.token, 'token-env');
+      final appId = ConfigProp.appIdProp.loadFrom(results);
+      final token = ConfigProp.tokenProp.loadFrom(results);
+      final apiKey = ConfigProp.apiKeyProp.loadFrom(results);
+      expect(appId, 'app-id-env');
+      expect(token, 'token-env');
+      expect(apiKey, 'api-key-env');
     });
 
     test('should parse with priority', () {
@@ -47,6 +53,7 @@ void main() {
         Environment(
           raygunAppId: 'app-id-env',
           raygunToken: 'token-env',
+          raygunApiKey: 'api-key-env',
         ),
       );
 
@@ -54,16 +61,23 @@ void main() {
       ArgParser parser = ArgParser()
         ..addFlag('verbose')
         ..addOption('app-id')
+        ..addOption('api-key')
         ..addOption('token');
 
       // parse arguments
-      final results =
-          parser.parse(['--app-id=app-id-parsed', '--token=token-parsed']);
+      final results = parser.parse([
+        '--app-id=app-id-parsed',
+        '--token=token-parsed',
+        '--api-key=api-key-parsed',
+      ]);
 
       // load from parsed even if env vars are set
-      final props = ConfigProps.load(results);
-      expect(props.appId, 'app-id-parsed');
-      expect(props.token, 'token-parsed');
+      final appId = ConfigProp.appIdProp.loadFrom(results);
+      final token = ConfigProp.tokenProp.loadFrom(results);
+      final apiKey = ConfigProp.apiKeyProp.loadFrom(results);
+      expect(appId, 'app-id-parsed');
+      expect(token, 'token-parsed');
+      expect(apiKey, 'api-key-parsed');
     });
 
     test('should parse from both', () {
@@ -73,6 +87,7 @@ void main() {
         Environment(
           raygunAppId: 'app-id-env',
           raygunToken: null,
+          raygunApiKey: null,
         ),
       );
 
@@ -86,9 +101,10 @@ void main() {
       final results = parser.parse(['--token=token-parsed']);
 
       // app-id from env, token from argument
-      final props = ConfigProps.load(results);
-      expect(props.appId, 'app-id-env');
-      expect(props.token, 'token-parsed');
+      final appId = ConfigProp.appIdProp.loadFrom(results);
+      final token = ConfigProp.tokenProp.loadFrom(results);
+      expect(appId, 'app-id-env');
+      expect(token, 'token-parsed');
     });
   });
 }


### PR DESCRIPTION
## perf: #5 refactor config props

### Description :memo:
- **Purpose**: Following the conversation in https://github.com/MindscapeHQ/raygun-cli/issues/5#issuecomment-2614181645 this PR refactors config props into individual parameters so they are easier to use.

The main idea of a "config prop" is to facilitate parsing either from arguments or env variables (and in the future from a config dot file as well).

- **Approach**: The `ConfigProps` class is now converted into the `ConfigProp` class, and static consts for each of the config properties (app id, token and api-key) are now individual `ConfigProp` const instances.

You can obtain the value (either from args or env-vars) calling like:

```dart
ConfigProp.token.from(arguments);
```

**Type of change**

- [x] Refactor

**Updates**

-  Refactored `ConfigProps` and `Environment` to support this change.
- Refactored all commands that used `ConfigProps` originally

### Test plan :test_tube:

Tested some commands to verify everything works as before:

```
➜  raygun-cli git:(config-props-optional) RAYGUN_API_KEY=123 RAYGUN_TOKEN=123 dart run bin/raygun_cli.dart deployments --version=1.2.3 --verbose
token: 123
api-key: 123
version: 1.2.3
owner-name: null
email-address: null
comment: null
scm-identifier: null
scm-type: null
....
```

Also updated unit tests.


### Author to check :eyeglasses:
- [ ] Project and all contained modules builds successfully
- [ ] Self-/dev-tested 
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)