### PR TITLE
ci: #3 Add binaries to Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,8 @@ jobs:
       - name: Build Linux binary
         run: dart compile exe bin/raygun_cli.dart -o raygun-cli
 
-      - uses: montudor/action-zip@v1
-        with:
-          args: zip -qq raygun-cli-linux.zip raygun-cli
+      - name: Zip Linux binary
+        run: zip raygun-cli-linux.zip raygun-cli
 
       - uses: AButler/upload-release-assets@v3.0
         with:
@@ -40,9 +39,8 @@ jobs:
       - name: Build MacOS binary
         run: dart compile exe bin/raygun_cli.dart -o raygun-cli
 
-      - uses: montudor/action-zip@v1
-        with:
-          args: zip -qq raygun-cli-macos.zip raygun-cli
+      - name: Zip MacOS binary
+        run: zip raygun-cli-macos.zip raygun-cli
 
       - uses: AButler/upload-release-assets@v3.0
         with:
@@ -62,9 +60,8 @@ jobs:
       - name: Build Windows binary
         run: dart compile exe bin/raygun_cli.dart -o raygun-cli.exe
 
-      - uses: montudor/action-zip@v1
-        with:
-          args: zip -qq raygun-cli-windows.zip raygun-cli.exe
+      - name: Zip Windows binary
+        run: 7z a -t7z raygun-cli-windows.zip raygun-cli.exe
 
       - uses: AButler/upload-release-assets@v3.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.ref }}
 
       - uses: dart-lang/setup-dart@v1
 
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.ref }}
 
       - uses: dart-lang/setup-dart@v1
 
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.ref }}
 
       - uses: dart-lang/setup-dart@v1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,10 @@ jobs:
         with:
           name: linux-binary
           path: raygun-cli
+      - uses: montudor/action-zip@v1
+        with:
+          args: zip -qq raygun-cli-linux.zip raygun-cli
       - uses: AButler/upload-release-assets@v3.0
         with:
-          files: "artifacts/*"
+          files: "raygun-cli-linux.zip"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release binaries
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Build Linux binary
+        run: dart compile exe bin/raygun_cli.dart -o raygun-cli
+
+      - name: Upload Linux binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-binary
+          path: raygun-cli
+      - uses: AButler/upload-release-assets@v3.0
+        with:
+          files: "artifacts/*"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,55 @@ jobs:
       - name: Build Linux binary
         run: dart compile exe bin/raygun_cli.dart -o raygun-cli
 
-      - name: Upload Linux binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-binary
-          path: raygun-cli
       - uses: montudor/action-zip@v1
         with:
           args: zip -qq raygun-cli-linux.zip raygun-cli
+
       - uses: AButler/upload-release-assets@v3.0
         with:
           files: "raygun-cli-linux.zip"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Build MacOS binary
+        run: dart compile exe bin/raygun_cli.dart -o raygun-cli
+
+      - uses: montudor/action-zip@v1
+        with:
+          args: zip -qq raygun-cli-macos.zip raygun-cli
+
+      - uses: AButler/upload-release-assets@v3.0
+        with:
+          files: "raygun-cli-macos.zip"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Build Windows binary
+        run: dart compile exe bin/raygun_cli.dart -o raygun-cli.exe
+
+      - uses: montudor/action-zip@v1
+        with:
+          args: zip -qq raygun-cli-windows.zip raygun-cli.exe
+
+      - uses: AButler/upload-release-assets@v3.0
+        with:
+          files: "raygun-cli-windows.zip"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - uses: dart-lang/setup-dart@v1
 
@@ -30,6 +32,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - uses: dart-lang/setup-dart@v1
 
@@ -51,6 +55,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - uses: dart-lang/setup-dart@v1
 


### PR DESCRIPTION
## ci: #3 Add binaries to Releases

### Description :memo:

- **Purpose**: This GitHub Actions workflow automatically builds binaries and uploads them to each release when a release is created.
- **Approach**: The job is triggered on release creation, it checkouts the release tag, then builds binaries for Linux, MacOS and Windows, then uploads them to the release that triggered the action.

- Related to #3 but does not close it, because we still need a way to distribute updates

**Type of change**

- [x] CI improvement

**Updates**

- Created release.yaml file

### Screenshots :camera:

![image](https://github.com/user-attachments/assets/4b8ec62b-f9fe-4300-bd72-f23e215b5828)

### Test plan :test_tube:

Tested in a fork, the resulting files can be seen here: https://github.com/miquelbeltran/raygun-cli/releases/tag/0.0.6

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)