### PR TITLE
chore: Prepare release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.0.0
+
+- feat: #8 Proguard/R8 (#14) (2025-01-27)
+- feat: #7 Support for new deployment command.
+- feat: #6 Support Environment variables.
+- perf: #5 refactor config props (#15) (2025-01-27)
+- fix: #2 improve pubdev scores (#16) (2025-01-28)
+- ci: #3 Add binaries to Releases (#17) (2025-01-27)
+- chore(deps): bump lints from 4.0.0 to 5.1.1 (#9) (2025-01-16)
+- chore(deps): bump args from 2.5.0 to 2.6.0 (#10) (2025-01-16)
+- chore(deps): bump test from 1.25.8 to 1.25.14 (2025-01-16)
+- chore: Moved project to https://github.com/MindscapeHQ/raygun-cli
+
 ## 0.0.2
 
 - Adds the `symbols` command to upload/list/delete Flutter symbols files on Raygun.com

--- a/bin/raygun_cli.dart
+++ b/bin/raygun_cli.dart
@@ -1,7 +1,7 @@
 import 'package:args/args.dart';
 import 'package:raygun_cli/raygun_cli.dart';
 
-const String version = '0.0.2';
+const String version = '1.0.0';
 
 ArgParser buildParser() {
   return ArgParser()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: raygun_cli
 description: A command-line tool for uploading sourcemaps, managing obfuscation symbols, and tracking deployments in Raygun.com
 # Update version in bin/raygun_cli.dart as well
-version: 0.0.2
+version: 1.0.0
 repository: https://github.com/MindscapeHQ/raygun-cli/
 homepage: https://raygun.com
 


### PR DESCRIPTION
## chore: Prepare release 1.0.0

### Description :memo:
- **Purpose**: Preparing release 1.0.0
- **Approach**: Bump version, update changelog and check publish dryrun

**Type of change**

- [x] release

**Updates**

- Bump version to 1.0.0
- Update changelog (note: some PRs were not merged using "Squash and merge" so commit history is a bit messy)

### Test plan :test_tube:

Release dryrun:

```
➜  raygun-cli git:(release/1.0.0) dart pub publish --dry-run
Resolving dependencies... 
Downloading packages... 
Got dependencies!
Publishing raygun_cli 1.0.0 to https://pub.dev:
├── CHANGELOG.md (<1 KB)
├── LICENSE (1 KB)
├── README.md (6 KB)
├── analysis_options.yaml (<1 KB)
├── bin
│   └── raygun_cli.dart (2 KB)
├── example
│   └── main.dart (<1 KB)
├── lib
│   ├── raygun_cli.dart (<1 KB)
│   └── src
│       ├── config_props.dart (1 KB)
│       ├── deployments
│       │   ├── deployments.dart (1 KB)
│       │   ├── deployments_api.dart (1 KB)
│       │   └── deployments_command.dart (1 KB)
│       ├── environment.dart (1 KB)
│       ├── proguard
│       │   ├── proguard.dart (1 KB)
│       │   ├── proguard_api.dart (1 KB)
│       │   └── proguard_command.dart (1 KB)
│       ├── sourcemap
│       │   ├── flutter
│       │   │   └── sourcemap_flutter.dart (1 KB)
│       │   ├── node
│       │   │   └── sourcemap_node.dart (<1 KB)
│       │   ├── sourcemap_api.dart (1 KB)
│       │   ├── sourcemap_base.dart (<1 KB)
│       │   ├── sourcemap_command.dart (1 KB)
│       │   └── sourcemap_single_file.dart (1 KB)
│       └── symbols
│           ├── flutter_symbols.dart (2 KB)
│           └── flutter_symbols_api.dart (2 KB)
├── pubspec.yaml (<1 KB)
├── pull_request_template.md (1 KB)
└── test
    └── config_props_test.dart (3 KB)

Total compressed archive size: 10 KB.
The server may enforce additional checks.

Package has 0 warnings.
```


### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)