### PR TITLE
chore: Prepare release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.3.0
+
+- feat: #5 add .env config file support (#62)
+- chore(deps): bump build_runner from 2.11.1 to 2.13.1 (#56)
+- chore(deps): bump test from 1.30.0 to 1.31.0 (#57)
+- chore(deps): bump mockito from 5.6.3 to 5.6.4 (#58)
+- chore(deps): bump build_runner from 2.13.1 to 2.15.0 (#59)
+- chore(deps): bump test from 1.31.0 to 1.31.1 (#60)
+- chore(deps): bump mockito from 5.6.4 to 5.6.5 (#61)
+
 ## 1.2.1
 
 - chore(deps): bump test from 1.29.0 to 1.30.0 (#53)

--- a/bin/raygun_cli.dart
+++ b/bin/raygun_cli.dart
@@ -2,7 +2,7 @@ import 'package:args/args.dart';
 import 'package:raygun_cli/raygun_cli.dart';
 import 'package:raygun_cli/src/config_file.dart';
 
-const String version = '1.2.1';
+const String version = '1.3.0';
 
 ArgParser buildParser() {
   return ArgParser()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: raygun_cli
 description: A command-line tool for uploading sourcemaps, managing obfuscation symbols, and tracking deployments in Raygun.com
 # Update version in bin/raygun_cli.dart as well
-version: 1.2.1
+version: 1.3.0
 repository: https://github.com/MindscapeHQ/raygun-cli/
 homepage: https://raygun.com
 


### PR DESCRIPTION
Prepares the 1.3.0 release.

## Version bump

- `pubspec.yaml`: 1.2.1 → 1.3.0
- `bin/raygun_cli.dart`: 1.2.1 → 1.3.0

## Changes since 1.2.1

- feat: #5 add .env config file support (#62)
- chore(deps): bump build_runner from 2.11.1 to 2.13.1 (#56)
- chore(deps): bump test from 1.30.0 to 1.31.0 (#57)
- chore(deps): bump mockito from 5.6.3 to 5.6.4 (#58)
- chore(deps): bump build_runner from 2.13.1 to 2.15.0 (#59)
- chore(deps): bump test from 1.31.0 to 1.31.1 (#60)
- chore(deps): bump mockito from 5.6.4 to 5.6.5 (#61)

Minor bump because #62 introduces a new user-facing capability (`.env` config file discovery).

## Release steps after merge

1. Create a GitHub Release tagged `1.3.0` targeting `main`.
2. The `release.yml` workflow will build and upload Linux, macOS, and Windows binaries automatically.

## Verification

- `dart format --set-exit-if-changed .` — clean
- `dart analyze` — no issues
- `dart test` — 145/145 passed