### PR TITLE
chore: harden lockfile build process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
-        run: dart pub get
+        run: dart pub get --enforce-lockfile
 
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .
@@ -34,16 +34,22 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
-        run: dart pub get
+        run: dart pub get --enforce-lockfile
 
       - name: Build Linux binary
         run: dart compile exe bin/raygun_cli.dart -o raygun-cli
+
+      - name: Generate artifact checksums
+        run: sha256sum raygun-cli pubspec.lock > SHA256SUMS
 
       - name: Upload Linux binary
         uses: actions/upload-artifact@v4
         with:
           name: linux-binary
-          path: raygun-cli
+          path: |
+            raygun-cli
+            pubspec.lock
+            SHA256SUMS
 
   build-macos:
     runs-on: macos-latest
@@ -53,16 +59,22 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
-        run: dart pub get
+        run: dart pub get --enforce-lockfile
 
       - name: Build MacOS binary
         run: dart compile exe bin/raygun_cli.dart -o raygun-cli
+
+      - name: Generate artifact checksums
+        run: shasum -a 256 raygun-cli pubspec.lock > SHA256SUMS
 
       - name: Upload MacOS binary
         uses: actions/upload-artifact@v4
         with:
           name: macos-binary
-          path: raygun-cli
+          path: |
+            raygun-cli
+            pubspec.lock
+            SHA256SUMS
 
   build-windows:
     runs-on: windows-latest
@@ -72,13 +84,21 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
-        run: dart pub get
+        run: dart pub get --enforce-lockfile
 
       - name: Build Windows binary
         run: dart compile exe bin/raygun_cli.dart -o raygun-cli.exe
+
+      - name: Generate artifact checksums
+        shell: pwsh
+        run: |
+          Get-FileHash raygun-cli.exe,pubspec.lock -Algorithm SHA256 | ForEach-Object { "$($_.Hash.ToLower())  $($_.Path | Split-Path -Leaf)" } | Set-Content SHA256SUMS
 
       - name: Upload Windows binary
         uses: actions/upload-artifact@v4
         with:
           name: windows-binary
-          path: raygun-cli.exe
+          path: |
+            raygun-cli.exe
+            pubspec.lock
+            SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,26 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
-        run: dart pub get
+        run: dart pub get --enforce-lockfile
 
       - name: Build Linux binary
         run: dart compile exe bin/raygun_cli.dart -o raygun-cli
 
+      - name: Create build manifest
+        run: |
+          cat > build-manifest.txt <<EOF
+          raygun-cli release build
+          git_ref=${GITHUB_REF}
+          git_sha=${GITHUB_SHA}
+          dart_sdk=$(dart --version 2>&1)
+          lockfile=pubspec.lock
+          EOF
+
+      - name: Generate checksums
+        run: sha256sum raygun-cli pubspec.lock build-manifest.txt > SHA256SUMS
+
       - name: Zip Linux binary
-        run: zip raygun-cli-linux.zip raygun-cli
+        run: zip raygun-cli-linux.zip raygun-cli pubspec.lock build-manifest.txt SHA256SUMS
 
       - uses: AButler/upload-release-assets@v3.0
         with:
@@ -38,13 +51,26 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
-        run: dart pub get
+        run: dart pub get --enforce-lockfile
 
       - name: Build MacOS binary
         run: dart compile exe bin/raygun_cli.dart -o raygun-cli
 
+      - name: Create build manifest
+        run: |
+          cat > build-manifest.txt <<EOF
+          raygun-cli release build
+          git_ref=${GITHUB_REF}
+          git_sha=${GITHUB_SHA}
+          dart_sdk=$(dart --version 2>&1)
+          lockfile=pubspec.lock
+          EOF
+
+      - name: Generate checksums
+        run: shasum -a 256 raygun-cli pubspec.lock build-manifest.txt > SHA256SUMS
+
       - name: Zip MacOS binary
-        run: zip raygun-cli-macos.zip raygun-cli
+        run: zip raygun-cli-macos.zip raygun-cli pubspec.lock build-manifest.txt SHA256SUMS
 
       - uses: AButler/upload-release-assets@v3.0
         with:
@@ -61,13 +87,30 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
-        run: dart pub get
+        run: dart pub get --enforce-lockfile
 
       - name: Build Windows binary
         run: dart compile exe bin/raygun_cli.dart -o raygun-cli.exe
 
+      - name: Create build manifest
+        shell: pwsh
+        run: |
+          $dartSdk = dart --version 2>&1
+          @(
+            'raygun-cli release build'
+            "git_ref=$env:GITHUB_REF"
+            "git_sha=$env:GITHUB_SHA"
+            "dart_sdk=$dartSdk"
+            'lockfile=pubspec.lock'
+          ) | Set-Content build-manifest.txt
+
+      - name: Generate checksums
+        shell: pwsh
+        run: |
+          Get-FileHash raygun-cli.exe,pubspec.lock,build-manifest.txt -Algorithm SHA256 | ForEach-Object { "$($_.Hash.ToLower())  $($_.Path | Split-Path -Leaf)" } | Set-Content SHA256SUMS
+
       - name: Zip Windows binary
-        run: 7z a -t7z raygun-cli-windows.zip raygun-cli.exe
+        run: 7z a -tzip raygun-cli-windows.zip raygun-cli.exe pubspec.lock build-manifest.txt SHA256SUMS
 
       - uses: AButler/upload-release-assets@v3.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Raygun CLI - Agent Guide
 
 ## Build/Test Commands
+- `dart pub get --enforce-lockfile` - Install dependencies from the committed lockfile
 - `dart test` - Run all tests
 - `dart test test/config_props_test.dart` - Run single test file
 - `dart analyze` - Run linter/analysis (uses package:lints/recommended.yaml)
@@ -189,8 +190,16 @@ final command = SymbolsCommand(api: mockApi);
 
 ### PR Requirements
 - **Title**: Must follow Conventional Commits (enforced by `.github/workflows/pr.yml`)
-- **Checks**: All must pass - format, analyze, test
+- **Checks**: All must pass - enforced lockfile install, format, analyze, test
 - **Platforms**: Multi-platform builds run automatically (Linux, macOS, Windows)
+
+### Lockfile and Supply-Chain Policy
+- `pubspec.lock` is intentionally committed because this repository builds a CLI executable and release binaries.
+- Use `dart pub get --enforce-lockfile` in CI, release workflows, and source-build verification. This fails when the lockfile is missing, out of sync with `pubspec.yaml`, or package content hashes do not match.
+- Dependency updates should be isolated to dependency-specific PRs, usually from Dependabot. Review `pubspec.lock` changes alongside any `pubspec.yaml` changes.
+- Do not broad-upgrade unrelated dependencies in feature or fix PRs unless needed for the task.
+- CI build artifacts include the compiled binary, `pubspec.lock`, and `SHA256SUMS`.
+- Release archives include the platform binary, `pubspec.lock`, `build-manifest.txt`, and `SHA256SUMS` so users can verify and reproduce builds from the tagged commit.
 
 ### Conventional Commits Format
 Examples:
@@ -206,8 +215,8 @@ Examples:
 
 ### Workflows
 - **pr.yml**: Validates PR title format
-- **main.yml**: Runs tests, format check, analysis, and builds binaries for all platforms
-- **release.yml**: On GitHub release, builds and uploads zipped binaries
+- **main.yml**: Enforces the lockfile, runs tests, format check, analysis, builds binaries for all platforms, and uploads binaries with lockfile/checksums
+- **release.yml**: On GitHub release, enforces the lockfile, builds zipped binaries, and includes lockfile/checksum/build-manifest files in each archive
 
 ## Development Workflow
 
@@ -235,6 +244,7 @@ export RAYGUN_API_KEY=test-api-key
 ### Build for Distribution
 ```bash
 # Compile for current platform
+dart pub get --enforce-lockfile
 dart compile exe bin/raygun_cli.dart -o raygun-cli
 
 # Note: Cross-compilation not supported; use CI for other platforms
@@ -356,12 +366,13 @@ A sample is committed at `example/.env.example`.
 
 ### Mock Generation Issues
 - Ensure `@GenerateMocks` annotation is present in test file
-- Run `dart pub get` to ensure dependencies are installed
+- Run `dart pub get --enforce-lockfile` to ensure dependencies are installed from the committed lockfile
 - Clean and rebuild: `dart run build_runner clean && dart run build_runner build`
 
 ### Build Issues
-- Ensure Dart SDK version matches `pubspec.yaml` requirement (^3.5.0)
-- Run `dart pub get` to update dependencies
+- Ensure Dart SDK version matches `pubspec.yaml` requirement (^3.10.0)
+- Run `dart pub get --enforce-lockfile` to verify the committed lockfile is usable
+- For intentional dependency updates, update `pubspec.yaml` if needed, run `dart pub upgrade <package>`, and commit the resulting `pubspec.lock`
 - Check that version in `bin/raygun_cli.dart` matches `pubspec.yaml`
 
 ### Test Failures

--- a/README.md
+++ b/README.md
@@ -30,11 +30,47 @@ dart pub global activate raygun_cli
 
 **Install from sources**
 
-Compile and install the this tool with the following command:
+Compile and install this tool with the following command:
 
 ```
+dart pub get --enforce-lockfile
 dart pub global activate -s path .
 ```
+
+The committed `pubspec.lock` is part of the source build contract. It pins the
+exact dependency graph and package content hashes used by CI and release builds,
+so keep it committed and use `dart pub get --enforce-lockfile` when building
+from a checkout.
+
+#### Reproducible builds and dependency updates
+
+This repository is a CLI application that produces release binaries, so
+`pubspec.lock` is intentionally tracked. Dependency updates should be isolated
+to dependency-specific PRs, usually from Dependabot, and the matching
+`pubspec.lock` changes should be reviewed alongside any `pubspec.yaml` changes.
+
+CI and release builds install dependencies with:
+
+```
+dart pub get --enforce-lockfile
+```
+
+This fails the build if the lockfile is missing, out of sync with
+`pubspec.yaml`, or if resolved package content does not match the hashes in the
+lockfile.
+
+Release archives include the platform binary, `pubspec.lock`, a build manifest,
+and `SHA256SUMS`. To rebuild a released binary from source, check out the
+release tag and run:
+
+```
+dart pub get --enforce-lockfile
+dart compile exe bin/raygun_cli.dart -o raygun-cli
+```
+
+When installing `raygun_cli` as a dependency or global package from pub.dev,
+Dart resolves dependencies in the consuming environment. The lockfile policy
+above applies to this repository's development, CI, and release artifacts.
 
 ### Usage
 
@@ -330,4 +366,3 @@ dart compile exe bin/raygun_cli.dart -o raygun-cli
 ```
 
 Note: The binary is compiled for the architecture and host system. To compile for macOS and Windows we must setup CI VMs. See: https://dart.dev/tools/dart-compile#known-limitations
-


### PR DESCRIPTION
## Summary
- enforce the committed Dart lockfile in CI and release builds
- include pubspec.lock and SHA256SUMS with CI build artifacts
- include pubspec.lock, SHA256SUMS, and a build manifest in release archives
- document the repo lockfile policy and reproducible source-build steps

## Verification
- dart pub get --enforce-lockfile
- git diff --check