### PR TITLE
chore: require Dart 3.11

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,7 +370,7 @@ A sample is committed at `example/.env.example`.
 - Clean and rebuild: `dart run build_runner clean && dart run build_runner build`
 
 ### Build Issues
-- Ensure Dart SDK version matches `pubspec.yaml` requirement (^3.10.0)
+- Ensure Dart SDK version matches `pubspec.yaml` requirement (^3.11.0)
 - Run `dart pub get --enforce-lockfile` to verify the committed lockfile is usable
 - For intentional dependency updates, update `pubspec.yaml` if needed, run `dart pub upgrade <package>`, and commit the resulting `pubspec.lock`
 - Check that version in `bin/raygun_cli.dart` matches `pubspec.yaml`

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -530,4 +530,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ executables:
   raygun-cli: 'raygun_cli'
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   args: ^2.6.0


### PR DESCRIPTION
## Summary
- bump the declared Dart SDK floor from ^3.10.0 to ^3.11.0
- update pubspec.lock's SDK range to match
- update AGENTS.md troubleshooting guidance

## Why
Dependabot PR #64 upgraded mockito to 5.7.0, which pulls analyzer 13 and _fe_analyzer_shared 100. Those packages require Dart 3.11+, so the repo should no longer advertise Dart 3.10 support.

## Verification
- dart pub get --enforce-lockfile
- dart analyze
- dart test
- dart format --output=none --set-exit-if-changed .
- git diff --check