### PR TITLE
chore: prepare release 2.0.0

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,12 +1,9 @@
-# https://dart.dev/guides/libraries/private-files
-# Created by `dart pub`
 .dart_tool/
-.idea/
 .env
-
 build/
 raygun-cli
 raygun-cli.exe
 raygun-cli-*.zip
 SHA256SUMS
 build-manifest.txt
+conference-talk-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.0
+
+- BREAKING: Require Dart SDK `^3.11.0` after dependency updates pulled in packages that no longer support Dart 3.10 (#67)
+- chore: Enforce the committed `pubspec.lock` in CI and release builds, and include lockfiles/checksums in build artifacts (#65)
+- chore: Rename `AGENT.md` to `AGENTS.md` and document the lockfile/release process (#65)
+- chore(deps): bump mockito from 5.6.4 to 5.7.0 (#64)
+
 ## 1.3.0
 
 - feat: #5 add .env config file support (#62)

--- a/bin/raygun_cli.dart
+++ b/bin/raygun_cli.dart
@@ -2,7 +2,7 @@ import 'package:args/args.dart';
 import 'package:raygun_cli/raygun_cli.dart';
 import 'package:raygun_cli/src/config_file.dart';
 
-const String version = '1.3.0';
+const String version = '2.0.0';
 
 ArgParser buildParser() {
   return ArgParser()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: raygun_cli
 description: A command-line tool for uploading sourcemaps, managing obfuscation symbols, and tracking deployments in Raygun.com
 # Update version in bin/raygun_cli.dart as well
-version: 1.3.0
+version: 2.0.0
 repository: https://github.com/MindscapeHQ/raygun-cli/
 homepage: https://raygun.com
 


### PR DESCRIPTION
## Summary
- bump raygun_cli from 1.3.0 to 2.0.0 in pubspec.yaml and bin/raygun_cli.dart
- document the 2.0.0 breaking Dart SDK floor change and release hardening changes in CHANGELOG.md
- add ignore rules so local binaries, release manifests, checksums, and notes are not accidentally published

## Why 2.0.0
The repo now requires Dart ^3.11.0 after the mockito/analyzer dependency update. Dropping Dart 3.10 support is a breaking environment change.

## Verification
- dart pub get --enforce-lockfile
- dart format --output=none --set-exit-if-changed .
- dart analyze
- dart test
- dart compile exe bin/raygun_cli.dart -o /tmp/raygun-cli-2.0.0
- dart run bin/raygun_cli.dart --version
- dart pub publish --dry-run
- git diff --check