### PR TITLE
docs: document public command API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .env
 
 build/
+doc/api/
 raygun-cli
 raygun-cli.exe
 raygun-cli-*.zip

--- a/.pubignore
+++ b/.pubignore
@@ -1,6 +1,7 @@
 .dart_tool/
 .env
 build/
+doc/api/
 raygun-cli
 raygun-cli.exe
 raygun-cli-*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- docs: Add dartdoc comments to the exported public command API to improve pub.dev documentation scoring.
+
 ## 2.0.0
 
 - BREAKING: Require Dart SDK `^3.11.0` after dependency updates pulled in packages that no longer support Dart 3.10 (#67)

--- a/bin/raygun_cli.dart
+++ b/bin/raygun_cli.dart
@@ -2,7 +2,7 @@ import 'package:args/args.dart';
 import 'package:raygun_cli/raygun_cli.dart';
 import 'package:raygun_cli/src/config_file.dart';
 
-const String version = '2.0.0';
+const String version = '2.0.1';
 
 ArgParser buildParser() {
   return ArgParser()

--- a/lib/raygun_cli.dart
+++ b/lib/raygun_cli.dart
@@ -1,3 +1,10 @@
+/// Public command API for the Raygun CLI.
+///
+/// Most users interact with this package through the `raygun-cli` executable.
+/// These exports expose the command implementations for tests, embedding, and
+/// advanced integrations that want to compose the CLI programmatically.
+library;
+
 export 'src/deployments/deployments_command.dart';
 export 'src/dsym/dsym_command.dart';
 export 'src/proguard/proguard_command.dart';

--- a/lib/src/deployments/deployments_command.dart
+++ b/lib/src/deployments/deployments_command.dart
@@ -5,18 +5,24 @@ import 'package:raygun_cli/src/core/raygun_command.dart';
 import 'package:raygun_cli/src/deployments/deployments.dart';
 import 'package:raygun_cli/src/deployments/deployments_api.dart';
 
+/// Default deployments command wired to the production Raygun API client.
 final DeploymentsCommand deploymentsCommand = DeploymentsCommand(
   api: DeploymentsApi.create(),
 );
 
+/// CLI command that records a deployment in Raygun.
 class DeploymentsCommand extends RaygunCommand {
+  /// Creates a deployments command that sends requests through [api].
   const DeploymentsCommand({required this.api});
 
+  /// API client used to create deployment records.
   final DeploymentsApi api;
 
+  /// Name used to invoke this command from the top-level CLI parser.
   @override
   String get name => 'deployments';
 
+  /// Builds the argument parser for deployment notification options.
   @override
   ArgParser buildParser() {
     return ArgParser()
@@ -63,6 +69,7 @@ class DeploymentsCommand extends RaygunCommand {
       ..addOption('comment', mandatory: false, help: 'Deployment comment');
   }
 
+  /// Executes the deployment command and exits with a process status code.
   @override
   void execute(ArgResults command, bool verbose) {
     if (command.wasParsed('help')) {

--- a/lib/src/dsym/dsym_command.dart
+++ b/lib/src/dsym/dsym_command.dart
@@ -5,16 +5,22 @@ import 'package:raygun_cli/src/core/raygun_command.dart';
 import 'package:raygun_cli/src/dsym/dsym.dart';
 import 'package:raygun_cli/src/dsym/dsym_api.dart';
 
+/// Default dSYM command wired to the production Raygun API client.
 final DsymCommand dsymCommand = DsymCommand(api: DsymApi.create());
 
+/// CLI command that uploads Apple dSYM archives to Raygun.
 class DsymCommand extends RaygunCommand {
+  /// Creates a dSYM command that sends requests through [api].
   const DsymCommand({required this.api});
 
+  /// API client used to upload dSYM archives.
   final DsymApi api;
 
+  /// Name used to invoke this command from the top-level CLI parser.
   @override
   String get name => 'dsym';
 
+  /// Builds the argument parser for dSYM upload options.
   @override
   ArgParser buildParser() {
     return ArgParser()
@@ -33,6 +39,7 @@ class DsymCommand extends RaygunCommand {
       ..addOption('path', mandatory: true, help: 'Path to the dSYM zip file');
   }
 
+  /// Executes the dSYM upload command and exits with a process status code.
   @override
   void execute(ArgResults command, bool verbose) {
     if (command.wasParsed('help')) {

--- a/lib/src/proguard/proguard_command.dart
+++ b/lib/src/proguard/proguard_command.dart
@@ -5,18 +5,24 @@ import 'package:raygun_cli/src/core/raygun_command.dart';
 import 'package:raygun_cli/src/proguard/proguard.dart';
 import 'package:raygun_cli/src/proguard/proguard_api.dart';
 
+/// Default ProGuard/R8 command wired to the production Raygun API client.
 final ProguardCommand proguardCommand = ProguardCommand(
   api: ProguardApi.create(),
 );
 
+/// CLI command that uploads Android ProGuard/R8 mapping files to Raygun.
 class ProguardCommand extends RaygunCommand {
+  /// Creates a ProGuard/R8 command that sends requests through [api].
   const ProguardCommand({required this.api});
 
+  /// API client used to upload mapping files.
   final ProguardApi api;
 
+  /// Name used to invoke this command from the top-level CLI parser.
   @override
   String get name => 'proguard';
 
+  /// Builds the argument parser for ProGuard/R8 upload options.
   @override
   ArgParser buildParser() {
     return ArgParser()
@@ -49,6 +55,7 @@ class ProguardCommand extends RaygunCommand {
       );
   }
 
+  /// Executes the ProGuard/R8 upload command and exits with a process status code.
   @override
   void execute(ArgResults command, bool verbose) {
     if (command.wasParsed('help')) {

--- a/lib/src/sourcemap/sourcemap_command.dart
+++ b/lib/src/sourcemap/sourcemap_command.dart
@@ -7,18 +7,24 @@ import 'package:raygun_cli/src/sourcemap/node/sourcemap_node.dart';
 import 'package:raygun_cli/src/sourcemap/sourcemap_api.dart';
 import 'package:raygun_cli/src/sourcemap/sourcemap_single_file.dart';
 
-SourcemapCommand sourcemapCommand = SourcemapCommand(
+/// Default sourcemap command wired to the production Raygun API client.
+final SourcemapCommand sourcemapCommand = SourcemapCommand(
   api: SourcemapApi.create(),
 );
 
+/// CLI command that uploads JavaScript sourcemaps to Raygun.
 class SourcemapCommand extends RaygunCommand {
+  /// Creates a sourcemap command that sends requests through [api].
   const SourcemapCommand({required this.api});
 
+  /// API client used to upload sourcemaps.
   final SourcemapApi api;
 
+  /// Name used to invoke this command from the top-level CLI parser.
   @override
   String get name => 'sourcemap';
 
+  /// Builds the argument parser for sourcemap upload options.
   @override
   ArgParser buildParser() {
     return ArgParser()
@@ -47,6 +53,7 @@ class SourcemapCommand extends RaygunCommand {
       ..addOption('src', abbr: 's', help: 'Source files');
   }
 
+  /// Executes the sourcemap command and exits with a process status code.
   @override
   void execute(ArgResults command, bool verbose) {
     if (command.wasParsed('help')) {
@@ -69,6 +76,7 @@ class SourcemapCommand extends RaygunCommand {
         });
   }
 
+  /// Runs the sourcemap upload workflow and returns whether it succeeded.
   Future<bool> run({required ArgResults command, required bool verbose}) async {
     if (command.wasParsed('help')) {
       print('Usage: raygun-cli sourcemap <arguments>');

--- a/lib/src/symbols/symbols_command.dart
+++ b/lib/src/symbols/symbols_command.dart
@@ -5,16 +5,22 @@ import 'package:raygun_cli/src/config_props.dart';
 import 'package:raygun_cli/src/core/raygun_command.dart';
 import 'package:raygun_cli/src/symbols/symbols_api.dart';
 
-SymbolsCommand symbolsCommand = SymbolsCommand(api: SymbolsApi.create());
+/// Default Flutter symbols command wired to the production Raygun API client.
+final SymbolsCommand symbolsCommand = SymbolsCommand(api: SymbolsApi.create());
 
+/// CLI command that uploads, lists, and deletes Flutter obfuscation symbols.
 class SymbolsCommand extends RaygunCommand {
+  /// Creates a symbols command that sends requests through [api].
   const SymbolsCommand({required this.api});
 
+  /// API client used to manage symbols files.
   final SymbolsApi api;
 
+  /// Name used to invoke this command from the top-level CLI parser.
   @override
   String get name => 'symbols';
 
+  /// Executes the symbols command and exits with a process status code.
   @override
   void execute(ArgResults command, bool verbose) {
     if (command.wasParsed('help')) {
@@ -40,6 +46,7 @@ class SymbolsCommand extends RaygunCommand {
         });
   }
 
+  /// Runs the selected symbols subcommand and returns whether it succeeded.
   Future<bool> run({
     required ArgResults command,
     required String appId,
@@ -77,6 +84,7 @@ class SymbolsCommand extends RaygunCommand {
     return false;
   }
 
+  /// Builds the argument parser for symbols upload, list, and delete options.
   @override
   ArgParser buildParser() {
     return ArgParser()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: raygun_cli
 description: A command-line tool for uploading sourcemaps, managing obfuscation symbols, and tracking deployments in Raygun.com
 # Update version in bin/raygun_cli.dart as well
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/MindscapeHQ/raygun-cli/
 homepage: https://raygun.com
 


### PR DESCRIPTION
## Summary
- add dartdoc comments to the exported public command API so pub.dev can award the public API documentation points
- prepare patch release 2.0.1 because pub.dev scoring is calculated from published package versions
- ignore generated dartdoc output in git/pub packaging

## Verification
- dart pub get --enforce-lockfile
- dart format --output=none --set-exit-if-changed .
- dart analyze
- dart test
- dart doc --dry-run
- dart run bin/raygun_cli.dart --version
- dart pub publish --dry-run
- git diff --check